### PR TITLE
inject ssl true/false into config from environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ EXPOSE 7143
 
 ENTRYPOINT echo $ots_domain | xargs -I domurl sed -ir 's/:domain:/:domain: domurl/g' /etc/onetime/config \
 && echo $ots_host | xargs -I hosturl sed -ir 's/:host:/:host: hosturl/g' /etc/onetime/config \
+&& echo $ots_ssl | xargs -I hostssl sed ir 's/:ssl:/:ssl: hostssl/g' /etc/onetime/config \
 && dd if=/dev/urandom bs=40 count=1 | openssl sha1 | grep stdin | awk '{print $2}' | xargs -I key sed -ir 's/:secret:/:secret: key/g' /etc/onetime/config \
 && cd /home/ots/onetime/ \
 && bundle exec thin -e dev -R config.ru -p 7143 start

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ EXPOSE 7143
 
 ENTRYPOINT echo $ots_domain | xargs -I domurl sed -ir 's/:domain:/:domain: domurl/g' /etc/onetime/config \
 && echo $ots_host | xargs -I hosturl sed -ir 's/:host:/:host: hosturl/g' /etc/onetime/config \
-&& echo $ots_ssl | xargs -I hostssl sed ir 's/:ssl:/:ssl: hostssl/g' /etc/onetime/config \
+&& echo $ots_ssl | xargs -I hostssl sed -ir 's/:ssl:/:ssl: hostssl/g' /etc/onetime/config \
 && dd if=/dev/urandom bs=40 count=1 | openssl sha1 | grep stdin | awk '{print $2}' | xargs -I key sed -ir 's/:secret:/:secret: key/g' /etc/onetime/config \
 && cd /home/ots/onetime/ \
 && bundle exec thin -e dev -R config.ru -p 7143 start

--- a/etc/config
+++ b/etc/config
@@ -1,7 +1,7 @@
 :site:
   :host:
   :domain:
-  :ssl: false
+  :ssl:
   # NOTE Once the secret is set, do not change it (keep a backup offsite)
   :secret: 
 :redis:


### PR DESCRIPTION
Ref: JIRA #SYS-1346

Allows us to specify true/false for ssl configuration with docker-compose.  Hopefully this would allow us to not host a service that stores secrets securely but then reveals them to you in plain http.

A concern I have is how the ssl config is treated.  If it instructs thin to listen on 443 instead of 80 and attempt to terminate SSL we'll have issues because the ELB is handling that.  All I really want it to do is give out secrets with "https://" instead of "http://"
